### PR TITLE
Update usage instructions for selecting Z.ai models in VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ Get your API key from [Z.ai Platform](https://open.bigmodel.cn/).
 Once configured, select Z.ai as your chat provider in VS Code Copilot Chat:
 
 - Open the Chat view (`Cmd/Ctrl + Alt + I`)
-- Click the provider selector
+- Click the Pick Model button (`Cmd/Ctrl + Alt + .`)
+- Open Manage Language Models menu (⚙️)
+- Click Z.ai models under `Z.ai` category to "Show in the chat model picker"
 - Choose a Z.ai model (GLM-4.5, GLM-4.6, GLM-4.7, GLM-4.7 Flash, GLM-5, GLM-5-Turbo, GLM-5.1, GLM-5V-Turbo, or GLM-5-Code)
   - Note: GLM-4.6V is used internally for image processing and is not selectable
 


### PR DESCRIPTION
Revise the documentation to clarify the steps for selecting Z.ai models in the VS Code Copilot Chat, including current button names and menu options.

Addresses #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * VS Code Copilot ChatにおけるZ.aiモデルの選択手順を更新しました。新しい手順では「Pick Model」ボタンを使用し、「Manage Language Models」メニューを開いてZ.aiモデルを有効にした後、チャットモデルピッカーからZ.aiモデルを選択できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->