### PR TITLE
feat: add welcome page with setup instructions on first install

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ src/
 
 ## Troubleshooting
 
+### Can't Access "Manage Language Models" Menu
+
+If you don't see the ⚙️ **Manage Language Models** option in Copilot Chat, make sure you have Copilot set up and enabled in VS Code. See [Set up Copilot](https://code.visualstudio.com/docs/copilot/setup) for instructions.
+
 ### API Key Issues
 
 If you see authentication errors:

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -176,10 +176,6 @@ export interface LanguageModelTool {
 
 export type LanguageModelChatTool = LanguageModelTool;
 
-export interface Disposable {
-  dispose(): void;
-}
-
 export type Event<T> = (listener: (e: T) => void) => Disposable;
 
 export class EventEmitter<T> {
@@ -219,6 +215,45 @@ export type LanguageModelResponsePart =
   | LanguageModelToolCallPart
   | LanguageModelToolResultPart
   | LanguageModelDataPart;
+
+export interface Uri {
+  toString(): string;
+}
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export enum ExtensionMode {
+  Production = 1,
+  Development = 2,
+  Test = 3,
+}
+
+export interface ExtensionContext {
+  globalState: {
+    get: <T = unknown>(key: string, defaultValue?: T) => T;
+    update: (key: string, value: unknown) => Promise<void>;
+    keys: () => string[];
+    setKeysForSync: (keys: string[]) => void;
+  };
+  secrets: SecretStorage;
+  subscriptions: Disposable[];
+  extensionUri: Uri;
+  extensionPath: string;
+  storageUri: Uri | undefined;
+  globalStorageUri: Uri;
+  logUri: Uri;
+  extensionMode: ExtensionMode;
+  environmentVariableCollection: any;
+  asAbsolutePath: (relativePath: string) => string;
+}
+
+export enum ViewColumn {
+  One = 1,
+  Two = 2,
+  Three = 3,
+}
 
 export class CancellationError extends Error {
   constructor() {
@@ -271,12 +306,14 @@ export const lm = {
 
 export const commands = {
   registerCommand: jest.fn(),
+  executeCommand: jest.fn(),
 };
 
 export const window = {
   showInputBox: jest.fn(),
   showInformationMessage: jest.fn(),
   showErrorMessage: jest.fn(),
+  createWebviewPanel: jest.fn(),
 };
 
 export const workspace = {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zai-vscode-chat",
   "displayName": "Z.ai Chat Provider for VS Code",
   "description": "Integrates Z.ai models (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5-Turbo, GLM-5.1, GLM-5V-Turbo, GLM-5-Code) into VS Code Copilot Chat with vision support and thinking process display",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "publisher": "Ryosuke-Asano",
   "license": "MIT",
   "repository": {
@@ -48,6 +48,11 @@
       {
         "command": "zai.manage",
         "title": "Manage Z.ai Provider",
+        "category": "Z.ai"
+      },
+      {
+        "command": "zai.welcome",
+        "title": "Welcome (Getting Started)",
         "category": "Z.ai"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import packageJson from "../package.json";
 import { ZaiChatModelProvider } from "./provider";
 import { registerZaiTools } from "./tools";
+import { shouldShowWelcome, showWelcomePanel } from "./welcome";
 
 // Global provider reference for API key management
 let _provider: ZaiChatModelProvider | null = null;
@@ -71,6 +72,20 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   console.log("[Z.ai Provider] Extension activated");
+
+  // Show welcome page on first install (when no API key is stored)
+  shouldShowWelcome(context).then((show) => {
+    if (show) {
+      showWelcomePanel(context, extVersion);
+    }
+  });
+
+  // Command to manually reopen the welcome page
+  context.subscriptions.push(
+    vscode.commands.registerCommand("zai.welcome", () => {
+      showWelcomePanel(context, extVersion);
+    })
+  );
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ export function activate(context: vscode.ExtensionContext) {
   console.log("[Z.ai Provider] Extension activated");
 
   // Show welcome page on first install (when no API key is stored)
-  shouldShowWelcome(context).then((show) => {
+  void shouldShowWelcome(context).then((show) => {
     if (show) {
       showWelcomePanel(context, extVersion);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,11 +74,15 @@ export function activate(context: vscode.ExtensionContext) {
   console.log("[Z.ai Provider] Extension activated");
 
   // Show welcome page on first install (when no API key is stored)
-  void shouldShowWelcome(context).then((show) => {
-    if (show) {
-      showWelcomePanel(context, extVersion);
-    }
-  });
+  void shouldShowWelcome(context)
+    .then((show) => {
+      if (show) {
+        showWelcomePanel(context, extVersion);
+      }
+    })
+    .catch((err: unknown) => {
+      console.error("[Z.ai Provider] Failed to show welcome panel:", err);
+    });
 
   // Command to manually reopen the welcome page
   context.subscriptions.push(

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -19,7 +19,7 @@ export function showWelcomePanel(
 
   // Handle the "Set API Key" button click
   panel.webview.onDidReceiveMessage(
-    async (message) => {
+    async (message: { command: string }) => {
       if (message.command === "setApiKey") {
         await vscode.commands.executeCommand("zai.manage");
         // Close the welcome panel after opening the key prompt

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -1,0 +1,219 @@
+import * as vscode from "vscode";
+
+/**
+ * Show a welcome/getting-started webview panel with setup instructions.
+ * Only shown when no API key is configured (first install).
+ */
+export function showWelcomePanel(
+  context: vscode.ExtensionContext,
+  extVersion: string
+): void {
+  const panel = vscode.window.createWebviewPanel(
+    "zaiWelcome",
+    "Welcome to Z.ai Chat Provider",
+    vscode.ViewColumn.One,
+    { enableScripts: true }
+  );
+
+  panel.webview.html = getWelcomeHtml(extVersion);
+
+  // Handle the "Set API Key" button click
+  panel.webview.onDidReceiveMessage(
+    async (message) => {
+      if (message.command === "setApiKey") {
+        await vscode.commands.executeCommand("zai.manage");
+        // Close the welcome panel after opening the key prompt
+        panel.dispose();
+      }
+    },
+    undefined,
+    context.subscriptions
+  );
+
+  // Mark that we've shown the welcome page so we don't show it again
+  context.globalState.update("zai.welcomeShown", true);
+}
+
+/**
+ * Check whether we should show the welcome panel (first install, no key).
+ */
+export async function shouldShowWelcome(
+  context: vscode.ExtensionContext
+): Promise<boolean> {
+  const apiKey = await context.secrets.get("zai.apiKey");
+  const alreadyShown = context.globalState.get<boolean>("zai.welcomeShown", false);
+  return !apiKey && !alreadyShown;
+}
+
+function getWelcomeHtml(extVersion: string): string {
+  return /*html*/ `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to Z.ai Chat Provider</title>
+  <style>
+    :root {
+      --bg: var(--vscode-editor-background);
+      --fg: var(--vscode-editor-foreground);
+      --accent: var(--vscode-button-background);
+      --accent-hover: var(--vscode-button-hoverBackground);
+      --accent-fg: var(--vscode-button-foreground);
+      --code-bg: var(--vscode-textCodeBlock-background);
+      --link: var(--vscode-textLink-foreground);
+      --border: var(--vscode-widget-border);
+    }
+    body {
+      font-family: var(--vscode-font-family);
+      color: var(--fg);
+      background: var(--bg);
+      max-width: 720px;
+      margin: 40px auto;
+      padding: 0 24px;
+      line-height: 1.6;
+    }
+    h1 {
+      font-size: 1.8em;
+      margin-bottom: 0.2em;
+    }
+    .subtitle {
+      color: var(--vscode-descriptionForeground);
+      margin-bottom: 2em;
+    }
+    h2 {
+      font-size: 1.3em;
+      margin-top: 1.8em;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 0.3em;
+    }
+    h3 {
+      font-size: 1.1em;
+      margin-top: 1.4em;
+      margin-bottom: 0.4em;
+    }
+    .step {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .step-number {
+      flex-shrink: 0;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: var(--accent-fg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      font-size: 0.9em;
+    }
+    .step-content {
+      padding-top: 3px;
+    }
+    code {
+      background: var(--code-bg);
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 0.9em;
+    }
+    .btn {
+      display: inline-block;
+      background: var(--accent);
+      color: var(--accent-fg);
+      border: none;
+      padding: 10px 24px;
+      font-size: 1em;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-top: 1.2em;
+      text-decoration: none;
+    }
+    .btn:hover {
+      background: var(--accent-hover);
+    }
+    .footer {
+      margin-top: 3em;
+      color: var(--vscode-descriptionForeground);
+      font-size: 0.85em;
+    }
+    .badge {
+      display: inline-block;
+      background: transparent;
+      color: var(--vscode-descriptionForeground);
+      padding: 0;
+      border-radius: 0;
+      font-size: 0.5em;
+      font-weight: 400;
+      vertical-align: middle;
+      margin-left: 8px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Z.ai Chat Provider <span class="badge">v${extVersion}</span></h1>
+  <p class="subtitle">Use Z.ai (智谱AI) models in VS Code Copilot Chat</p>
+
+  <p>
+    <strong>Prerequisite:</strong>
+    <a href="https://code.visualstudio.com/docs/copilot/setup">Set up Copilot</a>
+    to use AI features in VS Code before proceeding.
+  </p>
+
+  <h2>Setup — Set Your API Key</h2>
+
+  <p>Choose one of the following ways to configure your API key:</p>
+
+  <h3>Option A: Quick Setup</h3>
+  <p>Click the button below to enter your API key right away:</p>
+  <button class="btn" id="setApiKeyBtn">Set API Key Now</button>
+
+  <h3>Option B: Via Command Palette</h3>
+
+  <div class="step">
+    <div class="step-number">1</div>
+    <div class="step-content">Open Command Palette (<code>Cmd/Ctrl + Shift + P</code>)</div>
+  </div>
+  <div class="step">
+    <div class="step-number">2</div>
+    <div class="step-content">Run <code>Z.ai: Manage Z.ai Provider</code></div>
+  </div>
+  <div class="step">
+    <div class="step-number">3</div>
+    <div class="step-content">Enter your Z.ai API key</div>
+  </div>
+
+  <p>
+    Get your API key from
+    <a href="https://open.bigmodel.cn/">Z.ai Platform</a>.
+  </p>
+
+  <h2>After Setup</h2>
+  <ol>
+    <li>Open the Chat view (<code>Cmd/Ctrl + Alt + I</code>)</li>
+    <li>Click the Pick Model button (<code>Cmd/Ctrl + Alt + .</code>)</li>
+    <li>Open <strong>Manage Language Models</strong> menu (⚙️)</li>
+    <li>Click Z.ai models under <strong>Z.ai</strong> category to "Show in the chat model picker"</li>
+    <li>Choose a model (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5.1, GLM-5-Turbo, GLM-5V-Turbo, or GLM-5-Code)</li>
+  </ol>
+
+  <div class="footer">
+    <p>
+      <a href="https://github.com/Ryosuke-Asano/zai-provider-extension">GitHub</a> ·
+      <a href="https://z.ai">Z.ai</a> ·
+      <a href="https://open.bigmodel.cn/">Z.ai Platform</a>
+    </p>
+  </div>
+
+  <script>
+    const vscode = acquireVsCodeApi();
+    document.getElementById('setApiKeyBtn').addEventListener('click', () => {
+      vscode.postMessage({ command: 'setApiKey' });
+    });
+  </script>
+</body>
+</html>`;
+}

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -41,7 +41,10 @@ export async function shouldShowWelcome(
   context: vscode.ExtensionContext
 ): Promise<boolean> {
   const apiKey = await context.secrets.get("zai.apiKey");
-  const alreadyShown = context.globalState.get<boolean>("zai.welcomeShown", false);
+  const alreadyShown = context.globalState.get<boolean>(
+    "zai.welcomeShown",
+    false
+  );
   return !apiKey && !alreadyShown;
 }
 

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -12,7 +12,7 @@ export function showWelcomePanel(
     "zaiWelcome",
     "Welcome to Z.ai Chat Provider",
     vscode.ViewColumn.One,
-    { enableScripts: true }
+    { enableScripts: true, localResourceRoots: [] }
   );
 
   panel.webview.html = getWelcomeHtml(extVersion);
@@ -55,6 +55,7 @@ function getWelcomeHtml(extVersion: string): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
   <title>Welcome to Z.ai Chat Provider</title>
   <style>
     :root {
@@ -148,7 +149,7 @@ function getWelcomeHtml(extVersion: string): string {
       color: var(--vscode-descriptionForeground);
       padding: 0;
       border-radius: 0;
-      font-size: 0.5em;
+      font-size: 0.7em;
       font-weight: 400;
       vertical-align: middle;
       margin-left: 8px;

--- a/tests/welcome.test.ts
+++ b/tests/welcome.test.ts
@@ -1,0 +1,173 @@
+/// <reference types="jest" />
+
+import * as vscode from "vscode";
+import { shouldShowWelcome, showWelcomePanel } from "../src/welcome";
+
+function createMockContext() {
+  const globalState = new Map<string, unknown>();
+  const subscriptions: vscode.Disposable[] = [];
+
+  return {
+    globalState: {
+      get: jest.fn((key: string, defaultValue?: unknown) =>
+        globalState.has(key) ? globalState.get(key) : defaultValue
+      ),
+      update: jest.fn((key: string, value: unknown) => {
+        globalState.set(key, value);
+        return Promise.resolve();
+      }),
+      keys: jest.fn(() => Array.from(globalState.keys())),
+      setKeysForSync: jest.fn(),
+    },
+    secrets: {
+      get: jest.fn(),
+      store: jest.fn(),
+      delete: jest.fn(),
+      onDidChange: jest.fn(),
+    },
+    subscriptions,
+    extensionUri: {} as vscode.Uri,
+    extensionPath: "",
+    storageUri: undefined,
+    globalStorageUri: {} as vscode.Uri,
+    logUri: {} as vscode.Uri,
+    extensionMode: vscode.ExtensionMode.Test,
+    environmentVariableCollection: {} as any,
+    storageState: {
+      get: jest.fn(),
+      update: jest.fn(),
+      keys: jest.fn(() => []),
+    },
+    asAbsolutePath: jest.fn((p: string) => p),
+    secretsStorage: {} as any,
+  } as unknown as vscode.ExtensionContext;
+}
+
+describe("shouldShowWelcome", () => {
+  it("should return true when no API key is stored and welcome not shown", async () => {
+    const context = createMockContext();
+    (context.secrets.get as jest.Mock).mockResolvedValue(undefined);
+    (context.globalState.get as jest.Mock).mockReturnValue(false);
+
+    const result = await shouldShowWelcome(context);
+    expect(result).toBe(true);
+  });
+
+  it("should return false when API key is already stored", async () => {
+    const context = createMockContext();
+    (context.secrets.get as jest.Mock).mockResolvedValue("existing-key");
+    (context.globalState.get as jest.Mock).mockReturnValue(false);
+
+    const result = await shouldShowWelcome(context);
+    expect(result).toBe(false);
+  });
+
+  it("should return false when welcome was already shown", async () => {
+    const context = createMockContext();
+    (context.secrets.get as jest.Mock).mockResolvedValue(undefined);
+    (context.globalState.get as jest.Mock).mockReturnValue(true);
+
+    const result = await shouldShowWelcome(context);
+    expect(result).toBe(false);
+  });
+
+  it("should return false when both API key exists and welcome was shown", async () => {
+    const context = createMockContext();
+    (context.secrets.get as jest.Mock).mockResolvedValue("existing-key");
+    (context.globalState.get as jest.Mock).mockReturnValue(true);
+
+    const result = await shouldShowWelcome(context);
+    expect(result).toBe(false);
+  });
+});
+
+describe("showWelcomePanel", () => {
+  it("should create a webview panel with correct options", () => {
+    const context = createMockContext();
+    const mockWebview = {
+      html: "",
+      onDidReceiveMessage: jest.fn(),
+    };
+    const mockPanel = {
+      webview: mockWebview,
+      dispose: jest.fn(),
+    };
+    (vscode.window.createWebviewPanel as jest.Mock).mockReturnValue(mockPanel);
+
+    showWelcomePanel(context, "1.0.0");
+
+    expect(vscode.window.createWebviewPanel).toHaveBeenCalledWith(
+      "zaiWelcome",
+      "Welcome to Z.ai Chat Provider",
+      vscode.ViewColumn.One,
+      { enableScripts: true, localResourceRoots: [] }
+    );
+    expect(mockWebview.html).toContain("Welcome to Z.ai Chat Provider");
+    expect(mockWebview.html).toContain("v1.0.0");
+    expect(mockWebview.html).toContain("Content-Security-Policy");
+  });
+
+  it("should register a message handler for setApiKey command", () => {
+    const context = createMockContext();
+    const mockWebview = {
+      html: "",
+      onDidReceiveMessage: jest.fn(),
+    };
+    const mockPanel = {
+      webview: mockWebview,
+      dispose: jest.fn(),
+    };
+    (vscode.window.createWebviewPanel as jest.Mock).mockReturnValue(mockPanel);
+
+    showWelcomePanel(context, "1.0.0");
+
+    expect(mockWebview.onDidReceiveMessage).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      context.subscriptions
+    );
+  });
+
+  it("should mark welcome as shown in globalState", () => {
+    const context = createMockContext();
+    const mockWebview = {
+      html: "",
+      onDidReceiveMessage: jest.fn(),
+    };
+    const mockPanel = {
+      webview: mockWebview,
+      dispose: jest.fn(),
+    };
+    (vscode.window.createWebviewPanel as jest.Mock).mockReturnValue(mockPanel);
+
+    showWelcomePanel(context, "1.0.0");
+
+    expect(context.globalState.update).toHaveBeenCalledWith(
+      "zai.welcomeShown",
+      true
+    );
+  });
+
+  it("should call zai.manage and dispose panel when setApiKey is received", async () => {
+    const context = createMockContext();
+    const mockWebview = {
+      html: "",
+      onDidReceiveMessage: jest.fn(),
+    };
+    const mockPanel = {
+      webview: mockWebview,
+      dispose: jest.fn(),
+    };
+    (vscode.window.createWebviewPanel as jest.Mock).mockReturnValue(mockPanel);
+
+    showWelcomePanel(context, "1.0.0");
+
+    // Get the message handler that was registered
+    const messageHandler = mockWebview.onDidReceiveMessage.mock.calls[0][0];
+
+    await messageHandler({ command: "setApiKey" });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith("zai.manage");
+    expect(mockPanel.dispose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Hello,

  Thank you for reviewing the previous pull request on the project.
  This is a bit more work than the previous README edit so please feel free to edit the change as you see fit.
  My intention for the PR is to ease user onboarding process by:
(1) showing welcome panel on first use that reiterates setup process laid out in README
(2) augment README troubleshooting section because users who did not log in/configure GitHub Copilot will not be able to follow setup

Thanks.

---

This pull request introduces a welcome/getting-started experience for new users of the Z.ai Chat Provider extension, aiming to improve onboarding and setup. It adds a webview-based welcome panel that appears on first install (when no API key is set) and can be reopened via a new command. Additionally, it updates documentation and bumps the extension version.

**Onboarding & Welcome Experience:**
- Added a new `welcome.ts` module that provides a webview-based welcome panel with setup instructions, shown automatically on first install (when no API key is configured) and accessible via a new command. The panel includes a button for quick API key entry and detailed setup steps. (`src/welcome.ts`, [src/welcome.tsR1-R219](diffhunk://#diff-d2b8b31e7030d0d6182faff644e86af75a35c53cf90e8162d837a14f4b427c28R1-R219))
- Integrated the welcome panel logic into the extension activation flow: checks if the welcome should be shown, displays it if appropriate, and registers the `zai.welcome` command to manually reopen the panel. (`src/extension.ts`, [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R5) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R75-R88)
- Registered the new `zai.welcome` command in the extension manifest for use in the Command Palette. (`package.json`, [package.jsonR52-R56](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R52-R56))

**Documentation:**
- Added troubleshooting guidance for users unable to access the "Manage Language Models" menu in Copilot Chat, with a link to setup instructions. (`src/README.md`, [README.mdR176-R179](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R179))

**Versioning:**
- Bumped extension version from `0.8.5` to `0.8.6` to reflect these changes. (`package.json`, [package.jsonL5-R5](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 初回インストール時にウェルカムパネルを表示します。
  * 新しい「Welcome (Getting Started)」コマンドを追加しました。

* **ドキュメント**
  * 「Manage Language Models」メニューにアクセスできない場合のトラブルシューティングセクションをREADMEに追加しました。

* **バージョン**
  * バージョンを0.8.5から0.8.6にアップグレードしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->