### PR TITLE
fix: models missing from the model select in VS Code 1.120

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -245,6 +245,11 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
             toolCalling: model.supportsTools ? MAX_TOOLS_PER_REQUEST : false,
             imageInput: true, // Image input allowed; non-vision models auto-route
           },
+          isUserSelectable: true,
+          category: {
+            label: "Z.ai",
+            order: 2,
+          },
         };
       }
     );

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -246,10 +246,6 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
             imageInput: true, // Image input allowed; non-vision models auto-route
           },
           isUserSelectable: true,
-          category: {
-            label: "Z.ai",
-            order: 2,
-          },
         };
       }
     );


### PR DESCRIPTION
Fix: Models missing from the model select popup menu in VS Code 1.120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AI モデルがユーザー選択可能として表示されるようになりました
  * VS Code のモデル一覧で「Z.ai」カテゴリとして適切に分類されるようになりました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ryosuke-Asano/zai-provider-extension/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->