### PR TITLE
fix: mark models as user-selectable for VS Code 1.120

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -245,6 +245,7 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
             toolCalling: model.supportsTools ? MAX_TOOLS_PER_REQUEST : false,
             imageInput: true, // Image input allowed; non-vision models auto-route
           },
+          isUserSelectable: true,
         };
       }
     );


### PR DESCRIPTION
## Summary
Fixes Z.ai models not appearing in VS Code model picker after recent VS Code changes.

## What changed
- Added `isUserSelectable: true` to model information in `provideLanguageModelChatInformation`.

## Why
VS Code 1.120 requires models to be explicitly marked as user-selectable for them to appear in the model select UI.

## Verification
- `npm run compile` passes
- Extension packages successfully as `.vsix`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 言語モデル一覧でユーザーが選択可能なモデルが明示されるようになりました。モデル選択の際に、各モデルの選択可否情報が一目瞭然となり、ユーザー体験が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ryosuke-Asano/zai-provider-extension/pull/9)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->