### PR TITLE
feat: add GLM-5.2 model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GLM-5.2 model support (1M context window, 128K max output tokens)
+
 ## [0.9.1] - 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Integrates [Z.ai](https://z.ai) (智谱AI) models into VS Code Copilot Chat with
   - **GLM-4.7 Flash**: Faster variant with 131K max output tokens
   - **GLM-5**: 200K context window, up to 128K output tokens
   - **GLM-5.1**: 200K context window, up to 128K output tokens
+  - **GLM-5.2**: 1M context window, up to 128K output tokens
   - **GLM-5-Turbo**: 200K context window, up to 128K output tokens
   - **GLM-5V-Turbo**: Multimodal coding model with vision support
   - **GLM-5-Code**: 200K context window, up to 131K output tokens, optimized for coding
@@ -90,7 +91,7 @@ Once configured, select Z.ai as your chat provider in VS Code Copilot Chat:
 - Click the Pick Model button (`Cmd/Ctrl + Alt + .`)
 - Open Manage Language Models menu (⚙️)
 - Click Z.ai models under `Z.ai` category to "Show in the chat model picker"
-- Choose a Z.ai model (GLM-4.5, GLM-4.6, GLM-4.7, GLM-4.7 Flash, GLM-5, GLM-5-Turbo, GLM-5.1, GLM-5V-Turbo, or GLM-5-Code)
+- Choose a Z.ai model (GLM-4.5, GLM-4.6, GLM-4.7, GLM-4.7 Flash, GLM-5, GLM-5-Turbo, GLM-5.1, GLM-5.2, GLM-5V-Turbo, or GLM-5-Code)
   - Note: GLM-4.6V is used internally for image processing and is not selectable
 
 ### Configuration
@@ -113,6 +114,7 @@ Once configured, select Z.ai as your chat provider in VS Code Copilot Chat:
 | GLM-5         | 200,000        | 131,072    | No     | Yes   |
 | GLM-5-Turbo   | 200,000        | 131,072    | No     | Yes   |
 | GLM-5.1       | 200,000        | 131,072    | No     | Yes   |
+| GLM-5.2       | 1,000,000      | 131,072    | No     | Yes   |
 | GLM-5V-Turbo  | 200,000        | 131,072    | Yes    | Yes   |
 | GLM-5-Code    | 200,000        | 131,000    | No     | Yes   |
 
@@ -187,7 +189,7 @@ If you see authentication errors:
 
 ### Vision Not Working
 
-For non-vision models (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5.1, GLM-5-Code):
+For non-vision models (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5.1, GLM-5.2, GLM-5-Code):
 
 - Images are automatically converted to text descriptions using GLM-OCR MCP
 - If GLM-OCR fails, the extension internally uses GLM-4.6V for image analysis

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zai-vscode-chat",
   "displayName": "Z.ai Chat Provider for VS Code",
-  "description": "Integrates Z.ai models (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5-Turbo, GLM-5.1, GLM-5V-Turbo, GLM-5-Code) into VS Code Copilot Chat with vision support and thinking process display",
+  "description": "Integrates Z.ai models (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5-Turbo, GLM-5.1, GLM-5.2, GLM-5V-Turbo, GLM-5-Code) into VS Code Copilot Chat with vision support and thinking process display",
   "version": "0.9.1",
   "publisher": "Ryosuke-Asano",
   "license": "MIT",

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,17 @@ export const ZAI_MODELS: ZaiModelInfo[] = [
     supportsVision: false, // Text-only model
   },
   {
+    id: "glm-5.2",
+    name: "GLM-5.2",
+    displayName: "GLM-5.2",
+    // 1M-context variant (a.k.a. glm-5.2[1m] on the Anthropic-compatible endpoint);
+    // bare id on the OpenAI-compatible coding endpoint carries the 1M window.
+    contextWindow: 1000000,
+    maxOutput: 131072,
+    supportsTools: true,
+    supportsVision: false, // Text-only model
+  },
+  {
     id: "glm-5-turbo",
     name: "GLM-5-Turbo",
     displayName: "GLM-5-Turbo",

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -201,7 +201,7 @@ function getWelcomeHtml(extVersion: string): string {
     <li>Click the Pick Model button (<code>Cmd/Ctrl + Alt + .</code>)</li>
     <li>Open <strong>Manage Language Models</strong> menu (⚙️)</li>
     <li>Click Z.ai models under <strong>Z.ai</strong> category to "Show in the chat model picker"</li>
-    <li>Choose a model (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5.1, GLM-5-Turbo, GLM-5V-Turbo, or GLM-5-Code)</li>
+    <li>Choose a model (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5.1, GLM-5.2, GLM-5-Turbo, GLM-5V-Turbo, or GLM-5-Code)</li>
   </ol>
 
   <div class="footer">

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -391,6 +391,18 @@ describe("ZAI_MODELS", () => {
     expect(model?.maxOutput).toBe(131072);
   });
 
+  it("should have GLM-5.2 model", () => {
+    const model = ZAI_MODELS.find((m) => m.id === "glm-5.2");
+    expect(model).toBeDefined();
+    expect(model?.name).toBe("GLM-5.2");
+    expect(model?.displayName).toBe("GLM-5.2");
+    expect(model?.supportsTools).toBe(true);
+    expect(model?.supportsVision).toBe(false);
+    // Z.ai devpack docs: 1M context window, 131072 max output tokens
+    expect(model?.contextWindow).toBe(1000000);
+    expect(model?.maxOutput).toBe(131072);
+  });
+
   it("should all models have required fields", () => {
     ZAI_MODELS.forEach((model) => {
       expect(model.id).toBeDefined();


### PR DESCRIPTION
Hello,

  I noticed that Z.ai released GLM-5.2 model (https://x.com/Zai_org/status/2065704919299235870) and wanted to add its support in the extension.
  I used this resource to refer to the new model parameter: https://docs.z.ai/devpack/latest-model
  Please feel free to edit the change as you see fit. I have not touched version number.

Thanks.

---

This pull request adds support for the new GLM-5.2 model across the extension, documentation, and tests. GLM-5.2 offers a 1 million token context window and up to 128K output tokens. The changes ensure the model is selectable in the UI, listed in documentation, and covered by tests.

**GLM-5.2 Model Support**

- Added `GLM-5.2` to the `ZAI_MODELS` array in `src/types.ts` with a 1M context window and 131,072 max output tokens.
- Updated the test suite in `tests/types.test.ts` to include assertions for the new `GLM-5.2` model.

**Documentation Updates**

- Updated `README.md` to mention `GLM-5.2` in the supported models list, model picker instructions, feature table, and vision support notes.
- Added a changelog entry for GLM-5.2 model support in `CHANGELOG.md`.
- Updated the extension description in `package.json` to include `GLM-5.2`.
- Updated the welcome HTML in `src/welcome.ts` to list `GLM-5.2` as a selectable model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * GLM-5.2 モデルの対応を追加しました。コンテキストウィンドウ 1M、最大出力 128K に対応し、ツール機能もサポートしています。

* **Documentation**
  * README とウェルカムガイドを更新し、GLM-5.2 を対応モデル一覧に追加しました。

* **Tests**
  * GLM-5.2 の仕様検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->