### PR TITLE
fix: update mime type for usage reporting in ZaiChatModelProvider

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1092,15 +1092,18 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
         total_tokens: totalTokens,
       });
       try {
+        // Mime type MUST be the literal "usage" — VS Code's chat UI matches it
+        // against CustomDataPartMimeTypes.Usage (=== "usage") to populate the
+        // context-window percentage. A custom vnd.* type is silently ignored,
+        // which leaves the indicator stuck at 0%.
         progress.report(
           vscode.LanguageModelDataPart.json(
             {
-              type: "usage",
               prompt_tokens: this._usageMetrics.prompt_tokens,
               completion_tokens: this._usageMetrics.completion_tokens,
               total_tokens: totalTokens,
             },
-            "application/vnd.zai.usage+json"
+            "usage"
           )
         );
       } catch (e) {


### PR DESCRIPTION
Hello,

  I noticed with the current vs code 1.124.2 environment, context window display for z.ai provider models was malfunctioning (though it used to work previously if i remember correctly). I tried some debugging and at least to my end this change with vscode.LanguageModelDataPart.json() is enough to make it work again.
  Please feel free to review and edit the change as you see fit.

Thanks!

---

This pull request updates the way usage data is reported to VS Code's chat UI to ensure the context window indicator displays correctly. Instead of using a custom MIME type, the code now uses the literal "usage" type, which is recognized by VS Code.

Reporting and compatibility improvements:

* Changed the MIME type for usage data in the `progress.report` call from a custom `"application/vnd.zai.usage+json"` to the literal `"usage"`, ensuring correct integration with VS Code's context-window percentage indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 使用量メトリクスの報告形式を調整し、VS Codeとの互換性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->