### PR TITLE
feat: add Z.ai usage status bar indicator

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -236,6 +236,14 @@ export interface Disposable {
   dispose(): void;
 }
 
+/** Read/write key-value store backing globalState/workspaceState (vscode.Memento). */
+export interface Memento {
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  update(key: string, value: unknown): Promise<void>;
+  keys(): string[];
+}
+
 export enum ExtensionMode {
   Production = 1,
   Development = 2,
@@ -265,6 +273,60 @@ export enum ViewColumn {
   One = 1,
   Two = 2,
   Three = 3,
+}
+
+/** Alignment of a status bar item (mirrors vscode.StatusBarAlignment). */
+export enum StatusBarAlignment {
+  Left = 1,
+  Right = 2,
+}
+
+/**
+ * Wraps a theme color key (e.g. "charts.green"). Mock stores the id so tests
+ * can assert which color was selected.
+ */
+export class ThemeColor {
+  constructor(public readonly id: string) {}
+}
+
+/**
+ * Mockable markdown string. Records appended markdown so tests can inspect
+ * the assembled tooltip content.
+ */
+export class MarkdownString {
+  value = "";
+  isTrusted = false;
+  supportThemeIcons = false;
+  supportHtml = false;
+  constructor(value?: string, supportThemeIcons?: boolean) {
+    if (value) {
+      this.value = value;
+    }
+    this.supportThemeIcons = supportThemeIcons ?? false;
+  }
+  appendMarkdown(value: string): this {
+    this.value += value;
+    return this;
+  }
+  appendCodeblock(code: string, language?: string): this {
+    this.value += `\n\`\`\`${language ?? ""}\n${code}\n\`\`\`\n`;
+    return this;
+  }
+}
+
+/** Interface for a status bar item (mirrors vscode.StatusBarItem). */
+export interface StatusBarItem {
+  alignment: StatusBarAlignment;
+  priority: number;
+  text: string;
+  tooltip: string | MarkdownString | undefined;
+  color: string | ThemeColor | undefined;
+  backgroundColor: string | ThemeColor | undefined;
+  command: string | undefined;
+  name: string | undefined;
+  show(): void;
+  hide(): void;
+  dispose(): void;
 }
 
 export class CancellationError extends Error {
@@ -326,7 +388,44 @@ export const window = {
   showInformationMessage: jest.fn(),
   showErrorMessage: jest.fn(),
   createWebviewPanel: jest.fn(),
+  createStatusBarItem: jest.fn(
+    (
+      _alignment?: StatusBarAlignment,
+      _priority?: number
+    ): StatusBarItem => createMockStatusBarItem()
+  ),
 };
+
+/** Factory for a fully-mocked StatusBarItem that records its show/hide calls. */
+export function createMockStatusBarItem(): StatusBarItem {
+  const shownCalls: number[] = [];
+  const hiddenCalls: number[] = [];
+  const item: StatusBarItem = {
+    alignment: StatusBarAlignment.Right,
+    priority: 0,
+    text: "",
+    tooltip: undefined,
+    color: undefined,
+    backgroundColor: undefined,
+    command: undefined,
+    name: undefined,
+    show() {
+      shownCalls.push(1);
+    },
+    hide() {
+      hiddenCalls.push(1);
+    },
+    dispose() {
+      /* no-op */
+    },
+  };
+  // Stash call counters on the item for test assertions.
+  (item as unknown as { __shown: number[]; __hidden: number[] }).__shown =
+    shownCalls;
+  (item as unknown as { __shown: number[]; __hidden: number[] }).__hidden =
+    hiddenCalls;
+  return item;
+}
 
 export const workspace = {
   getConfiguration: jest.fn((_section?: string) => ({

--- a/package.json
+++ b/package.json
@@ -54,6 +54,16 @@
         "command": "zai.welcome",
         "title": "Welcome (Getting Started)",
         "category": "Z.ai"
+      },
+      {
+        "command": "zai.toggleUsageStatusBar",
+        "title": "Toggle Usage Status Bar",
+        "category": "Z.ai"
+      },
+      {
+        "command": "zai.refreshUsage",
+        "title": "Refresh Usage",
+        "category": "Z.ai"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import packageJson from "../package.json";
 import { ZaiChatModelProvider } from "./provider";
 import { registerZaiTools } from "./tools";
 import { shouldShowWelcome, showWelcomePanel } from "./welcome";
+import { ZaiUsageMonitor } from "./usage";
 
 // Global provider reference for API key management
 let _provider: ZaiChatModelProvider | null = null;
@@ -34,6 +35,25 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(registration);
 
   console.log("[Z.ai Provider] Z.ai provider registered successfully");
+
+  // Usage / quota status bar indicator. Visibility is user-toggleable;
+  // key/auth/network problems render a grayed-out state but stay visible.
+  const usageMonitor = new ZaiUsageMonitor(
+    context.secrets,
+    context.globalState
+  );
+  context.subscriptions.push(usageMonitor);
+  // Refresh the indicator right after each completed Z.ai chat response.
+  provider.onResponseComplete = () => void usageMonitor.refresh();
+  // Re-evaluate the indicator immediately when the API key changes.
+  context.subscriptions.push(
+    context.secrets.onDidChange((e) => {
+      if (e.key === "zai.apiKey") {
+        void usageMonitor.refresh();
+      }
+    })
+  );
+  usageMonitor.start();
 
   // Register Z.ai tools (vision analysis, etc.) for Copilot to use
   const toolsRegistration = registerZaiTools(context.secrets);
@@ -72,6 +92,25 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   console.log("[Z.ai Provider] Extension activated");
+
+  // Toggle the usage status bar indicator on/off (preference persisted).
+  context.subscriptions.push(
+    vscode.commands.registerCommand("zai.toggleUsageStatusBar", async () => {
+      const enabled = await usageMonitor.toggle();
+      vscode.window.showInformationMessage(
+        enabled
+          ? "Z.ai usage indicator shown."
+          : "Z.ai usage indicator hidden."
+      );
+    })
+  );
+
+  // Manually refresh the usage status bar indicator.
+  context.subscriptions.push(
+    vscode.commands.registerCommand("zai.refreshUsage", () => {
+      void usageMonitor.refresh();
+    })
+  );
 
   // Show welcome page on first install (when no API key is stored)
   void shouldShowWelcome(context)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -112,6 +112,13 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
   /** Track whether usage metrics have been reported for the current request */
   private _usageReported = false;
 
+  /**
+   * Optional callback fired once after each completed chat response.
+   * Wired by extension.ts to refresh the Z.ai usage status bar indicator.
+   * Fire-and-forget; errors thrown here are swallowed by the caller.
+   */
+  onResponseComplete?: () => void;
+
   /** Debug counter */
   private _debugCallCount = 0;
 
@@ -1068,6 +1075,19 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
       this._reasoningContentBuffer = "";
       this._usageMetrics = { prompt_tokens: 0, completion_tokens: 0 };
       this._usageReported = false;
+    }
+
+    // Notify listeners that a Z.ai response just completed so they can
+    // refresh account-wide usage (e.g. the status bar indicator).
+    this.fireResponseComplete();
+  }
+
+  /** Fire the onResponseComplete callback once, swallowing any errors. */
+  private fireResponseComplete(): void {
+    try {
+      this.onResponseComplete?.();
+    } catch (e) {
+      console.warn("[Z.ai Model Provider] onResponseComplete callback failed", e);
     }
   }
 

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,439 @@
+import * as vscode from "vscode";
+
+/**
+ * Z.ai usage / quota status bar indicator.
+ *
+ * Shows the account's Token-window usage percentage in the status bar,
+ * color-coded by tier (green / yellow / red), with a rich hover tooltip
+ * that lists each quota window (Token 5h / MCP 1mo), the used amount,
+ * limit, percentage, and a humanized "resets in ..." countdown derived
+ * from the API's `nextResetTime`.
+ *
+ * Visibility is governed ONLY by a user toggle. Key / auth / network
+ * problems do NOT hide the item — instead they render a grayed-out
+ * error state so the problem stays visible.
+ *
+ * The status bar calls `https://api.z.ai/api/monitor/usage/quota/limit`
+ * directly via the global `fetch` (self-contained; no external tool).
+ */
+
+/** Secret key used across the extension (same as src/mcp.ts / src/provider.ts). */
+const API_KEY_SECRET = "zai.apiKey";
+
+/** Quota limit endpoint (verified working with `Authorization: Bearer <key>`). */
+const QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit";
+
+/** Poll interval (ms). Overridable via the globalState key below for testing. */
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Persisted-toggle globalState key. */
+const TOGGLE_STATE_KEY = "zai.usageStatusBarEnabled";
+
+/** Codicon shown before the percentage in the normal state. */
+const NORMAL_ICON = "$(pulse)";
+/** Codicon shown in error / grayed-out states. */
+const ERROR_ICON = "$(warning)";
+
+/** Status bar alignment + priority (right side, fairly high). */
+const STATUS_BAR_ALIGNMENT = vscode.StatusBarAlignment.Right;
+const STATUS_BAR_PRIORITY = 100;
+
+/** Limit type identifiers returned by the quota API. */
+type LimitType = string;
+
+/** A single usage-detail row (per-model breakdown for the MCP window). */
+interface UsageDetail {
+  modelCode?: string;
+  usage?: number;
+}
+
+/** One quota window as returned by `data.limits[]`. */
+interface QuotaLimit {
+  type: LimitType;
+  /** Window size magnitude (e.g. 5 for 5h, 1 for 1 month). */
+  unit?: number;
+  /** Window size count paired with `unit`. */
+  number?: number;
+  /** % used (0–100). Present for every limit type. */
+  percentage?: number;
+  /** Epoch-ms timestamp when this window resets. Present for every limit type. */
+  nextResetTime?: number;
+  /** Hard limit value (MCP window only). */
+  usage?: number;
+  /** Current consumed amount (MCP window only). */
+  currentValue?: number;
+  /** Remaining amount (MCP window only). */
+  remaining?: number;
+  /** Per-model breakdown (MCP window only). */
+  usageDetails?: UsageDetail[];
+}
+
+/** Top-level quota response. */
+interface QuotaResponse {
+  code?: number;
+  success?: boolean;
+  data?: {
+    level?: string;
+    limits?: QuotaLimit[];
+  };
+}
+
+/** Normalized quota window used for rendering. */
+interface QuotaWindow {
+  /** Display label, e.g. "Token (5h)". */
+  label: string;
+  /** % used (0–100). */
+  percentage: number;
+  /** Epoch-ms when the window resets (undefined when unknown). */
+  nextResetTime?: number;
+  /** Current consumed amount (optional; TOKENS_LIMIT omits it). */
+  currentValue?: number;
+  /** Hard limit amount (optional; TOKENS_LIMIT omits it). */
+  limit?: number;
+  /** Per-model breakdown rows (optional). */
+  usageDetails?: UsageDetail[];
+}
+
+/** Why the indicator is currently in an error / grayed-out state. */
+type ErrorState = "no-key" | "auth" | "network" | undefined;
+
+/**
+ * Humanize a remaining duration (ms) into a compact countdown string.
+ *
+ * - `< 60m`        → "45m"
+ * - `< 24h`        → "3h 20m"
+ * - `< 30d`        → "2d 5h"
+ * - `>= 30d`       → "27d"
+ * - `<= 0`         → "0m" (window rolled over; refresh will correct it)
+ *
+ * Pure function — trivially unit-testable.
+ */
+export function formatDuration(ms: number): string {
+  if (ms <= 0) {
+    return "0m";
+  }
+  const totalMinutes = Math.floor(ms / (60 * 1000));
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days >= 1) {
+    // Omit a trailing zero hours component (e.g. "27d", not "27d 0h").
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (hours >= 1) {
+    // Omit a trailing zero minutes component (e.g. "3h", not "3h 0m").
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
+/** Pick a toned-down foreground `ThemeColor` for a given used-percentage. */
+function colorForPercentage(percentage: number): vscode.ThemeColor {
+  if (percentage >= 95) {
+    return new vscode.ThemeColor("charts.red");
+  }
+  if (percentage >= 80) {
+    return new vscode.ThemeColor("charts.yellow");
+  }
+  return new vscode.ThemeColor("charts.green");
+}
+
+/**
+ * Owns the Z.ai usage status bar item: fetches quota, polls on a timer,
+ * refreshes on demand, and renders either a normal or a grayed-out error
+ * state. Visibility is controlled solely by the user toggle.
+ */
+export class ZaiUsageMonitor implements vscode.Disposable {
+  private readonly _secrets: vscode.SecretStorage;
+  private readonly _globalState: vscode.Memento;
+  private readonly _item: vscode.StatusBarItem;
+  private readonly _pollIntervalMs: number;
+
+  private _timer: NodeJS.Timeout | undefined;
+  private _windows: QuotaWindow[] = [];
+  private _errorState: ErrorState = undefined;
+  private _userEnabled: boolean;
+
+  constructor(
+    secrets: vscode.SecretStorage,
+    globalState: vscode.Memento,
+    pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS
+  ) {
+    this._secrets = secrets;
+    this._globalState = globalState;
+    this._pollIntervalMs = pollIntervalMs;
+
+    // Restore persisted toggle (default ON).
+    this._userEnabled =
+      this._globalState.get<boolean>(TOGGLE_STATE_KEY) ?? true;
+
+    this._item = vscode.window.createStatusBarItem(
+      STATUS_BAR_ALIGNMENT,
+      STATUS_BAR_PRIORITY
+    );
+    this._item.name = "Z.ai Usage";
+    this._item.command = "zai.refreshUsage";
+    this.applyVisibility();
+  }
+
+  /** Begin polling and do an initial refresh. Safe to call once on activate. */
+  start(): void {
+    void this.refresh();
+    this._timer = setInterval(() => {
+      void this.refresh();
+    }, this._pollIntervalMs);
+  }
+
+  /** Stop the polling timer. */
+  stop(): void {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = undefined;
+    }
+  }
+
+  /** Dispose the status bar item and the polling timer. */
+  dispose(): void {
+    this.stop();
+    this._item.dispose();
+  }
+
+  /**
+   * Flip the user toggle, persist it, and show/hide accordingly.
+   * Returns the new enabled state.
+   */
+  async toggle(): Promise<boolean> {
+    this._userEnabled = !this._userEnabled;
+    await this._globalState.update(TOGGLE_STATE_KEY, this._userEnabled);
+    this.applyVisibility();
+    return this._userEnabled;
+  }
+
+  /** Current toggle state (exposed for tests / inspection). */
+  get enabled(): boolean {
+    return this._userEnabled;
+  }
+
+  /**
+   * Fetch the latest quota and re-render. Never throws: any failure is
+   * translated into a grayed-out error state so the indicator stays
+   * visible to signal the problem.
+   */
+  async refresh(): Promise<void> {
+    const apiKey = await this._secrets.get(API_KEY_SECRET);
+    if (!apiKey) {
+      this._errorState = "no-key";
+      this._windows = [];
+      this.render();
+      return;
+    }
+
+    try {
+      const windows = await this.fetchQuota(apiKey);
+      this._windows = windows;
+      this._errorState = undefined;
+      this.render();
+    } catch (err) {
+      this._errorState = this.classifyError(err);
+      this._windows = [];
+      this.render();
+    }
+  }
+
+  /**
+   * Call the quota endpoint. Throws a tagged error on auth failure so the
+   * caller can distinguish auth vs network problems.
+   */
+  private async fetchQuota(apiKey: string): Promise<QuotaWindow[]> {
+    const response = await fetch(QUOTA_URL, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      throw new AuthError(
+        `Z.ai API key rejected (${response.status})`,
+        response.status
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Z.ai usage API error: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const body = (await response.json()) as QuotaResponse;
+    const limits = body?.data?.limits ?? [];
+    return limits.map(toWindow).filter((w): w is QuotaWindow => w !== null);
+  }
+
+  /** Map an HTTP/fetch failure to the appropriate {@link ErrorState}. */
+  private classifyError(err: unknown): ErrorState {
+    if (err instanceof AuthError) {
+      return "auth";
+    }
+    return "network";
+  }
+
+  /** Show or hide the item based solely on the user toggle. */
+  private applyVisibility(): void {
+    if (this._userEnabled) {
+      this._item.show();
+      // Ensure the displayed content matches the current state when re-shown.
+      this.render();
+    } else {
+      this._item.hide();
+    }
+  }
+
+  /** Re-render the status bar text / color / tooltip for the current state. */
+  private render(): void {
+    if (!this._userEnabled) {
+      return; // hidden; nothing to paint
+    }
+
+    if (this._errorState) {
+      this.renderError();
+      return;
+    }
+    this.renderNormal();
+  }
+
+  /** Grayed-out error state: dim color, warning icon, explanatory tooltip. */
+  private renderError(): void {
+    this._item.text = `${ERROR_ICON} Z.ai`;
+    this._item.color = new vscode.ThemeColor("disabledForeground");
+    this._item.backgroundColor = undefined;
+    this._item.tooltip = this.buildErrorTooltip(this._errorState!);
+  }
+
+  /** Normal state: percentage text + tier color + detailed markdown tooltip. */
+  private renderNormal(): void {
+    const tokenWindow = this._windows.find((w) => w.label.startsWith("Token"));
+    const percentage = tokenWindow?.percentage ?? 0;
+    const rounded = Math.round(percentage);
+
+    this._item.text = `${NORMAL_ICON} Z.ai ${rounded}%`;
+    this._item.color = colorForPercentage(percentage);
+    this._item.backgroundColor = undefined;
+    this._item.tooltip = this.buildNormalTooltip();
+  }
+
+  /** Build the markdown hover tooltip for the error state. */
+  private buildErrorTooltip(
+    state: Exclude<ErrorState, undefined>
+  ): vscode.MarkdownString {
+    const md = new vscode.MarkdownString(undefined, true);
+    md.isTrusted = true;
+    md.supportThemeIcons = true;
+    md.supportHtml = true;
+
+    let message: string;
+    switch (state) {
+      case "no-key":
+        message =
+          "No Z.ai API key set. Run **Z.ai: Manage Z.ai Provider** to add one.";
+        break;
+      case "auth":
+        message =
+          "Z.ai API key rejected (401/403). Update it via **Z.ai: Manage Z.ai Provider**.";
+        break;
+      default:
+        message =
+          "Unable to reach the Z.ai usage API (network error). Will retry.";
+        break;
+    }
+
+    md.appendMarkdown(`$(warning) **Z.ai Usage — Unavailable**\n\n`);
+    md.appendMarkdown(message);
+    md.appendMarkdown(`\n\n---\n`);
+    md.appendMarkdown(
+      `[Refresh](command:zai.refreshUsage) · [Hide](command:zai.toggleUsageStatusBar)`
+    );
+    return md;
+  }
+
+  /** Build the markdown hover tooltip for the normal state. */
+  private buildNormalTooltip(): vscode.MarkdownString {
+    const md = new vscode.MarkdownString(undefined, true);
+    md.isTrusted = true;
+    md.supportThemeIcons = true;
+    md.supportHtml = true;
+
+    md.appendMarkdown(`$(pulse) **Z.ai Usage**\n\n`);
+    md.appendMarkdown(
+      "| Window | Used | Limit | % | Resets in |\n|---|---|---|---|---|\n"
+    );
+
+    for (const w of this._windows) {
+      const used = w.currentValue != null ? String(w.currentValue) : "—";
+      const limit = w.limit != null ? String(w.limit) : "—";
+      const pct = `${Math.round(w.percentage)}%`;
+      const resets =
+        w.nextResetTime != null
+          ? formatDuration(w.nextResetTime - Date.now())
+          : "—";
+      md.appendMarkdown(
+        `| ${w.label} | ${used} | ${limit} | ${pct} | ${resets} |\n`
+      );
+    }
+
+    // Append per-model breakdown for windows that expose it (MCP).
+    const detailWindow = this._windows.find(
+      (w) => w.usageDetails && w.usageDetails.length > 0
+    );
+    if (detailWindow?.usageDetails?.length) {
+      md.appendMarkdown(`\n**${detailWindow.label} breakdown**\n\n`);
+      md.appendMarkdown(`| Model | Usage |\n|---|---|\n`);
+      for (const d of detailWindow.usageDetails) {
+        md.appendMarkdown(
+          `| ${d.modelCode ?? "—"} | ${d.usage ?? 0} |\n`
+        );
+      }
+    }
+
+    md.appendMarkdown(`\n---\n`);
+    md.appendMarkdown(
+      `[Refresh](command:zai.refreshUsage) · [Hide](command:zai.toggleUsageStatusBar)`
+    );
+    return md;
+  }
+}
+
+/** Error tag used to distinguish auth failures from network errors. */
+class AuthError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+/**
+ * Convert a raw API limit object into a normalized {@link QuotaWindow}.
+ * Returns null for unknown / unsupported limit types.
+ */
+function toWindow(limit: QuotaLimit): QuotaWindow | null {
+  switch (limit.type) {
+    case "TOKENS_LIMIT":
+      return {
+        label: "Token (5h)",
+        percentage: limit.percentage ?? 0,
+        nextResetTime: limit.nextResetTime,
+      };
+    case "TIME_LIMIT":
+      return {
+        label: "MCP (1mo)",
+        percentage: limit.percentage ?? 0,
+        nextResetTime: limit.nextResetTime,
+        currentValue: limit.currentValue,
+        limit: limit.usage,
+        usageDetails: limit.usageDetails,
+      };
+    default:
+      return null;
+  }
+}

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -204,6 +204,14 @@ function getWelcomeHtml(extVersion: string): string {
     <li>Choose a model (GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, GLM-5.1, GLM-5.2, GLM-5-Turbo, GLM-5V-Turbo, or GLM-5-Code)</li>
   </ol>
 
+  <h2>Usage Indicator</h2>
+  <p>
+    A Z.ai usage indicator appears in the status bar, showing your Token-window
+    usage at a glance (color-coded green / yellow / red). Hover it for a per-window
+    breakdown and reset countdown. Run <code>Z.ai: Toggle Usage Status Bar</code>
+    to hide or show it.
+  </p>
+
   <div class="footer">
     <p>
       <a href="https://github.com/Ryosuke-Asano/zai-provider-extension">GitHub</a> ·

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -179,4 +179,37 @@ describe("ZaiChatModelProvider", () => {
     );
     expect(count).toBe(Math.ceil(text.length / 2));
   });
+
+  it("should fire onResponseComplete once after a completed chat response", async () => {
+    const provider = new ZaiChatModelProvider(
+      secrets as unknown as vscode.SecretStorage,
+      "jest-agent"
+    );
+    const models = await provider.provideLanguageModelChatInformation(
+      { silent: true } as vscode.PrepareLanguageModelChatModelOptions,
+      createToken()
+    );
+    const glm5 = models.find((m) => m.id === "glm-5");
+    if (!glm5) {
+      throw new Error("glm-5 not found");
+    }
+
+    const callback = jest.fn();
+    provider.onResponseComplete = callback;
+
+    const messages = [vscode.LanguageModelChatMessage.User("hello")];
+    const progress = {
+      report: jest.fn(),
+    } as unknown as vscode.Progress<vscode.LanguageModelResponsePart>;
+
+    await provider.provideLanguageModelChatResponse(
+      glm5,
+      messages,
+      {},
+      progress,
+      createToken()
+    );
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -1,0 +1,291 @@
+/// <reference types="jest" />
+import * as vscode from "vscode";
+import { ZaiUsageMonitor, formatDuration } from "../src/usage";
+import { createMockStatusBarItem } from "../__mocks__/vscode";
+
+/** Build a mock SecretStorage with an overridable API key. */
+function createSecrets(key: string | undefined) {
+  return {
+    get: jest.fn().mockResolvedValue(key),
+    store: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    onDidChange: jest.fn(),
+  } as unknown as vscode.SecretStorage;
+}
+
+/** Build a mock Memento (globalState) backed by a Map. */
+function createGlobalState(initial: Record<string, unknown> = {}) {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: jest.fn(<T = unknown>(key: string, defaultValue?: T): T =>
+      store.has(key) ? (store.get(key) as T) : (defaultValue as T)
+    ),
+    update: jest.fn((key: string, value: unknown) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    keys: jest.fn(() => Array.from(store.keys())),
+  } as unknown as vscode.Memento;
+}
+
+/** Build a quota response body matching the verified API shape. */
+function quotaResponse(
+  tokenPct: number,
+  tokenResetMs: number,
+  mcpPct: number,
+  mcpResetMs: number,
+  extras: Partial<{
+    currentValue: number;
+    usage: number;
+    remaining: number;
+    usageDetails: { modelCode: string; usage: number }[];
+  }> = {}
+) {
+  return {
+    code: 200,
+    success: true,
+    data: {
+      level: "max",
+      limits: [
+        {
+          type: "TIME_LIMIT",
+          unit: 5,
+          number: 1,
+          usage: extras.usage ?? 4000,
+          currentValue: extras.currentValue ?? 25,
+          remaining: extras.remaining ?? 3975,
+          percentage: mcpPct,
+          nextResetTime: mcpResetMs,
+          usageDetails: extras.usageDetails ?? [
+            { modelCode: "search-prime", usage: 11 },
+            { modelCode: "web-reader", usage: 14 },
+          ],
+        },
+        {
+          type: "TOKENS_LIMIT",
+          unit: 3,
+          number: 5,
+          percentage: tokenPct,
+          nextResetTime: tokenResetMs,
+        },
+      ],
+    },
+  };
+}
+
+/** Create a monitor against fresh mocks + a known item handle. */
+function createMonitor(
+  key: string | undefined,
+  state: Record<string, unknown> = {},
+  pollMs = 60000
+) {
+  const secrets = createSecrets(key);
+  const globalState = createGlobalState(state);
+  // Reset any stale return value left by a previous test (clearAllMocks does
+  // NOT clear mockReturnValue), then hand back a fresh, isolated item.
+  const statusMock = vscode.window.createStatusBarItem as jest.Mock;
+  statusMock.mockReset();
+  statusMock.mockImplementation(() => createMockStatusBarItem());
+  const item = statusMock() as unknown as vscode.StatusBarItem & {
+    __shown: number[];
+    __hidden: number[];
+  };
+  statusMock.mockReturnValue(item);
+  const monitor = new ZaiUsageMonitor(secrets, globalState, pollMs);
+  return { monitor, secrets, globalState, item };
+}
+
+/** Helper to read the rendered tooltip markdown value (mock stores a MarkdownString). */
+function tooltipText(item: vscode.StatusBarItem): string {
+  const tip = item.tooltip as unknown as vscode.MarkdownString | string;
+  return typeof tip === "string" ? tip : tip?.value ?? "";
+}
+
+describe("formatDuration", () => {
+  const MIN = 60 * 1000;
+  const HOUR = 60 * MIN;
+  const DAY = 24 * HOUR;
+
+  it("formats sub-hour durations as minutes", () => {
+    expect(formatDuration(45 * MIN)).toBe("45m");
+    expect(formatDuration(0)).toBe("0m");
+    expect(formatDuration(1 * MIN)).toBe("1m");
+  });
+
+  it("formats sub-day durations as hours+minutes", () => {
+    expect(formatDuration(3 * HOUR + 20 * MIN)).toBe("3h 20m");
+  });
+
+  it("formats sub-month durations as days+hours", () => {
+    expect(formatDuration(2 * DAY + 5 * HOUR)).toBe("2d 5h");
+  });
+
+  it("formats month+ durations as days only", () => {
+    expect(formatDuration(27 * DAY)).toBe("27d");
+    expect(formatDuration(30 * DAY)).toBe("30d");
+  });
+
+  it("clamps non-positive durations to 0m", () => {
+    expect(formatDuration(0)).toBe("0m");
+    expect(formatDuration(-1000)).toBe("0m");
+  });
+});
+
+describe("ZaiUsageMonitor — visibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows the item by default when enabled (independent of key/auth state)", async () => {
+    const { item } = createMonitor(undefined);
+    // Constructor calls applyVisibility() → show() when enabled (default true).
+    expect(item.__shown.length).toBeGreaterThan(0);
+  });
+
+  it("hides the item when the toggle is disabled in persisted state", async () => {
+    const { item } = createMonitor("key", { "zai.usageStatusBarEnabled": false });
+    expect(item.__hidden.length).toBeGreaterThan(0);
+    expect(item.__shown.length).toBe(0);
+  });
+
+  it("toggle flips visibility and persists the preference", async () => {
+    const { monitor, item, globalState } = createMonitor("key");
+    expect(monitor.enabled).toBe(true);
+
+    const nowEnabled = await monitor.toggle();
+    expect(nowEnabled).toBe(false);
+    expect(monitor.enabled).toBe(false);
+    expect(item.__hidden.length).toBeGreaterThan(0);
+    expect(globalState.update).toHaveBeenCalledWith(
+      "zai.usageStatusBarEnabled",
+      false
+    );
+
+    const again = await monitor.toggle();
+    expect(again).toBe(true);
+    expect(item.__shown.length).toBeGreaterThan(1);
+  });
+});
+
+describe("ZaiUsageMonitor — error states", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  it("renders a grayed-out error state when no API key is set (still visible)", async () => {
+    const { monitor, item } = createMonitor(undefined);
+    await monitor.refresh();
+
+    expect(item.text).toContain("$(warning)");
+    expect(item.color).toEqual(new vscode.ThemeColor("disabledForeground"));
+    // Still visible (shown), not hidden.
+    expect(item.__shown.length).toBeGreaterThan(0);
+    expect(tooltipText(item)).toContain("No Z.ai API key set");
+  });
+
+  it("renders a grayed-out error state on auth failure (401)", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: async () => "unauthorized",
+    });
+    const { monitor, item } = createMonitor("bogus-key");
+    await monitor.refresh();
+
+    expect(item.text).toContain("$(warning)");
+    expect(item.color).toEqual(new vscode.ThemeColor("disabledForeground"));
+    expect(tooltipText(item)).toContain("API key rejected");
+    expect(item.__shown.length).toBeGreaterThan(0);
+  });
+
+  it("renders a grayed-out error state on network error", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("network down"));
+    const { monitor, item } = createMonitor("some-key");
+    await monitor.refresh();
+
+    expect(item.text).toContain("$(warning)");
+    expect(tooltipText(item)).toContain("network error");
+    expect(item.__shown.length).toBeGreaterThan(0);
+  });
+});
+
+describe("ZaiUsageMonitor — normal state", () => {
+  const NOW = Date.now();
+  const HOUR = 60 * 60 * 1000;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Lock Date.now so the reset countdown is deterministic.
+    jest.spyOn(Date, "now").mockReturnValue(NOW);
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockQuota(tokenPct: number) {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () =>
+        quotaResponse(tokenPct, NOW + 3 * HOUR, 1, NOW + 11 * 24 * HOUR),
+    });
+  }
+
+  it("shows the token percentage with the pulse icon", async () => {
+    mockQuota(73);
+    const { monitor, item } = createMonitor("real-key");
+    await monitor.refresh();
+
+    expect(item.text).toBe("$(pulse) Z.ai 73%");
+  });
+
+  it("uses the green tier below 80%", async () => {
+    mockQuota(72);
+    const { monitor, item } = createMonitor("real-key");
+    await monitor.refresh();
+    expect(item.color).toEqual(new vscode.ThemeColor("charts.green"));
+    expect(item.backgroundColor).toBeUndefined();
+  });
+
+  it("uses the yellow tier at 80-95%", async () => {
+    mockQuota(88);
+    const { monitor, item } = createMonitor("real-key");
+    await monitor.refresh();
+    expect(item.color).toEqual(new vscode.ThemeColor("charts.yellow"));
+    expect(item.backgroundColor).toBeUndefined();
+  });
+
+  it("uses the red tier at >=95%", async () => {
+    mockQuota(97);
+    const { monitor, item } = createMonitor("real-key");
+    await monitor.refresh();
+    expect(item.color).toEqual(new vscode.ThemeColor("charts.red"));
+    expect(item.backgroundColor).toBeUndefined();
+  });
+
+  it("clicking triggers the refresh command", async () => {
+    mockQuota(10);
+    const { item } = createMonitor("real-key");
+    expect(item.command).toBe("zai.refreshUsage");
+  });
+
+  it("tooltip lists both windows, a reset countdown, and command links", async () => {
+    mockQuota(50);
+    const { monitor, item } = createMonitor("real-key");
+    await monitor.refresh();
+
+    const tip = tooltipText(item);
+    expect(tip).toContain("Token (5h)");
+    expect(tip).toContain("MCP (1mo)");
+    // Token window resets in ~3h.
+    expect(tip).toContain("3h");
+    expect(tip).toContain("[Refresh](command:zai.refreshUsage)");
+    expect(tip).toContain("[Hide](command:zai.toggleUsageStatusBar)");
+    // MCP window exposes a per-model breakdown.
+    expect(tip).toContain("search-prime");
+  });
+});


### PR DESCRIPTION
Hello,

  This is a feature PR and not-so small fix PR so please feel free to review and edit the change as you see fit.
  My intention for the PR is to add (basic) usage/quota tracking feature for z.ai coding plan users by checking up on `https://api.z.ai/api/monitor/usage/quota/limit` endpoint using the stored API key. 
  This works for me in particular currently, but since I'm (yet) on their legacy plan I am less sure if the API returns different results for other users using their 'current' coding plan which as far as I know brings in weekly limit quota in addition to existing 5hr limit quota. I think it will still work without showing weekly data per current implementation (so safe to merge without breaking) but if possible we should gather API result examples from those 'current' plan users and augment the handling. (Can you check your result?)

Thanks!

---

This pull request introduces a new Z.ai usage/quota indicator in the VS Code status bar, providing users with real-time feedback on their token usage, error states, and reset countdowns. It includes a toggleable status bar item, commands for manual refresh and visibility control, and comprehensive tests for all usage monitor behaviors. The changes also add supporting mocks and documentation updates.

**Status Bar Usage Indicator Feature:**

- Added a `ZaiUsageMonitor` class that displays a color-coded usage/quota indicator in the status bar, including error handling for missing keys, auth failures, and network errors. The indicator can be toggled on/off by the user, and is refreshed automatically after each chat response or when the API key changes. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R6)], [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R39-R57)], [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R96-R114)], [[4]](diffhunk://#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3R115-R121)], [[5]](diffhunk://#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3R1079-R1091)])

- Registered new commands in `package.json` for toggling (`zai.toggleUsageStatusBar`) and manually refreshing (`zai.refreshUsage`) the usage indicator. ([[package.jsonR57-R66](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R57-R66)])

**Mocks and Testing Support:**

- Enhanced the VS Code mock module with interfaces and classes for `Memento`, `StatusBarItem`, `StatusBarAlignment`, `ThemeColor`, and `MarkdownString`, and added a factory for a fully-mocked status bar item to support testing. [[1]](diffhunk://#diff-4a11f0823c80586f76439575e524317303c6e02f074884e08a346696aa2e6af4R239-R246)], [[2]](diffhunk://#diff-4a11f0823c80586f76439575e524317303c6e02f074884e08a346696aa2e6af4R278-R331)], [[3]](diffhunk://#diff-4a11f0823c80586f76439575e524317303c6e02f074884e08a346696aa2e6af4R391-R429)])

- Added a new test suite (`tests/usage.test.ts`) covering all aspects of the usage monitor: visibility toggling, error states, normal operation, color tiers, and tooltip content. ([[tests/usage.test.tsR1-R291](diffhunk://#diff-660517ba19ce8c61db2732e77a97d7f8365a6615148623bb375edb7948bde819R1-R291)])

**Documentation and User Guidance:**

- Updated the welcome HTML to explain the new usage indicator, its color coding, and how to toggle its visibility. ([[src/welcome.tsR207-R214](diffhunk://#diff-d2b8b31e7030d0d6182faff644e86af75a35c53cf90e8162d837a14f4b427c28R207-R214)])

**Provider Integration:**

- Modified the `ZaiChatModelProvider` to support an `onResponseComplete` callback, which is triggered after each chat response to keep the usage indicator up to date. [[1]](diffhunk://#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3R115-R121)], [[2]](diffhunk://#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3R1079-R1091)])

**Test Coverage:**

- Added a unit test to verify that `onResponseComplete` is fired exactly once after a chat response. ([[tests/provider.test.tsR182-R214](diffhunk://#diff-22cab369930e3165402e6f8f4b4b294fe62cf4360118c9e2fc8692f6727b9575R182-R214)])
