### PR TITLE
added thinking effort picker for glm-5.2

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -144,6 +144,23 @@ export class LanguageModelChatMessage {
   }
 }
 
+export interface LanguageModelConfigurationSchemaProperty {
+  type?: string;
+  title?: string;
+  enum?: readonly string[];
+  enumItemLabels?: readonly string[];
+  enumDescriptions?: readonly string[];
+  default?: unknown;
+  description?: string;
+  group?: string;
+}
+
+export interface LanguageModelConfigurationSchema {
+  properties?: {
+    readonly [key: string]: LanguageModelConfigurationSchemaProperty;
+  };
+}
+
 export interface LanguageModelChatInformation {
   id: string;
   name: string;
@@ -156,6 +173,7 @@ export interface LanguageModelChatInformation {
     toolCalling?: boolean | number;
     imageInput?: boolean;
   };
+  configurationSchema?: LanguageModelConfigurationSchema;
 }
 
 export interface ProvideLanguageModelChatResponseOptions {
@@ -165,6 +183,7 @@ export interface ProvideLanguageModelChatResponseOptions {
     top_p?: number;
     stop?: string | string[];
   };
+  modelConfiguration?: { readonly [key: string]: any };
   tools?: readonly LanguageModelTool[];
   toolMode?: LanguageModelChatToolMode;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zai-vscode-chat",
-  "version": "0.8.4",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zai-vscode-chat",
-      "version": "0.8.4",
+      "version": "0.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -57,7 +57,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1743,7 +1742,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2252,7 +2250,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2506,7 +2503,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2880,7 +2876,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3632,7 +3627,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5673,7 +5667,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5830,7 +5823,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
+  "enabledApiProposals": [
+    "chatProvider",
+    "languageModelThinkingPart"
+  ],
   "contributes": {
     "languageModelChatProviders": [
       {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,6 +17,7 @@ import type {
   ZaiStreamResponse,
   Json,
   ZaiRequestBody,
+  ZaiReasoningEffort,
 } from "./types";
 import { ZAI_MODELS } from "./types";
 import {
@@ -56,6 +57,63 @@ const DEFAULT_MAX_TOKENS = 65536;
 const MAX_RETRIES = 10;
 const BASE_RETRY_DELAY_MS = 2000;
 const RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504];
+
+/**
+ * Effort levels exposed in the picker for GLM-5.2.
+ *
+ * Per the Z.ai API docs, `reasoning_effort` is "Only supported by GLM-5.2" and
+ * "takes effect when thinking is enabled". The docs' enum lists seven values,
+ * but on GLM-5.2 only three produce a distinct outcome — the rest are
+ * compatibility aliases the server collapses onto these:
+ *   - max        ← (native) the documented default
+ *   - xhigh      → mapped to `max`
+ *   - high       ← (native)
+ *   - medium, low → mapped to `high`
+ *   - none, minimal → skip thinking
+ *
+ * To avoid showing "fake" (no-op) levels, only the three distinct outcomes are
+ * offered. For other models the param is unsupported, so no picker is
+ * contributed (see `supportsReasoningEffort` in types.ts).
+ */
+const REASONING_EFFORT_LEVELS: readonly string[] = ["max", "high", "none"];
+
+const REASONING_EFFORT_LABELS: Record<string, string> = {
+  max: "Max",
+  high: "High",
+  none: "None",
+};
+
+const REASONING_EFFORT_DESCRIPTIONS: Record<string, string> = {
+  max: "Absolute maximum capability with no constraints (default)",
+  high: "Greater reasoning depth but slower",
+  none: "No reasoning; the model skips thinking",
+};
+
+/**
+ * JSON-schema describing the "Thinking Effort" picker contributed to the model
+ * menu for GLM-5.2. `group: 'navigation'` renders it as a primary action next to
+ * the model picker. The selected value is forwarded to the provider via
+ * `modelConfiguration.reasoningEffort`.
+ */
+const REASONING_EFFORT_SCHEMA: vscode.LanguageModelConfigurationSchema = {
+  properties: {
+    reasoningEffort: {
+      type: "string",
+      title: "Thinking Effort",
+      enum: REASONING_EFFORT_LEVELS as string[],
+      enumItemLabels: REASONING_EFFORT_LEVELS.map(
+        (l) => REASONING_EFFORT_LABELS[l] ?? l
+      ),
+      enumDescriptions: REASONING_EFFORT_LEVELS.map(
+        (l) => REASONING_EFFORT_DESCRIPTIONS[l] ?? l
+      ),
+      default: "max",
+      description:
+        "Controls reasoning depth. Only supported by GLM-5.2; takes effect when thinking is enabled.",
+      group: "navigation",
+    },
+  },
+};
 
 /**
  * VS Code Chat provider backed by Z.ai API.
@@ -262,6 +320,11 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
             imageInput: true, // Image input allowed; non-vision models auto-route
           },
           isUserSelectable: true,
+          // GLM-5.2 exposes a "Thinking Effort" picker next to the model picker.
+          // The user's selection is forwarded to the provider via modelConfiguration.
+          configurationSchema: model.supportsReasoningEffort
+            ? REASONING_EFFORT_SCHEMA
+            : undefined,
         };
       }
     );
@@ -598,11 +661,29 @@ export class ZaiChatModelProvider implements LanguageModelChatProvider {
         temperature: temperatureVal,
       };
 
+      // Resolve per-model reasoning effort selected in the model picker.
+      // GLM-5.2 declares a `reasoningEffort` configurationSchema option; VS Code
+      // forwards the user's selection via `modelConfiguration` (proposed chatProvider API)
+      // or `modelOptions` (stable). Read both defensively.
+      const modelConfig =
+        (options.modelConfiguration as Record<string, Json> | undefined) ?? mo;
+      const reasoningEffort = modelConfig?.reasoningEffort as
+        | ZaiReasoningEffort
+        | undefined;
+
       // Enable thinking mode if setting is enabled
       if (this.isThinkingEnabled()) {
         requestBody.thinking = {
           type: "enabled",
         };
+        // reasoning_effort is only supported by GLM-5.2 and takes effect when
+        // thinking is enabled. Forward the picker selection verbatim (the docs'
+        // default is `max`; VS Code resolves schema defaults when untouched).
+        // The API applies the documented compatibility mappings:
+        //   none/minimal → skip thinking; low/medium → high; xhigh → max.
+        if (effectiveModelInfo?.supportsReasoningEffort && reasoningEffort) {
+          requestBody.reasoning_effort = reasoningEffort;
+        }
       }
 
       // Allow-list model options

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,28 @@ export interface ZaiModelInfo {
    * For example, `glm-5v-turbo` may be kept for internal vision fallback.
    */
   internal?: boolean;
+  /**
+   * When true, the model supports the `reasoning_effort` parameter
+   * (takes effect when `thinking` is enabled). Currently GLM-5.2 only.
+   */
+  supportsReasoningEffort?: boolean;
 }
+
+/**
+ * Reasoning effort levels supported by GLM-5.2.
+ * Takes effect when `thinking` is enabled. Default is `max`.
+ * - `none` / `minimal`: model skips thinking
+ * - `low` / `medium`: mapped to `high` by the API
+ * - `xhigh`: mapped to `max` by the API
+ */
+export type ZaiReasoningEffort =
+  | "max"
+  | "xhigh"
+  | "high"
+  | "medium"
+  | "low"
+  | "minimal"
+  | "none";
 
 /**
  * A strongly-typed request body used for Z.ai Chat API requests
@@ -139,6 +160,8 @@ export interface ZaiRequestBody {
   max_tokens?: number;
   temperature?: number;
   thinking?: { type: string };
+  /** Controls reasoning effort level. Only supported by GLM-5.2. */
+  reasoning_effort?: ZaiReasoningEffort;
   stop?: string | string[];
   frequency_penalty?: number;
   presence_penalty?: number;
@@ -223,6 +246,7 @@ export const ZAI_MODELS: ZaiModelInfo[] = [
     maxOutput: 131072,
     supportsTools: true,
     supportsVision: false, // Text-only model
+    supportsReasoningEffort: true, // Only GLM-5.2 supports reasoning_effort
   },
   {
     id: "glm-5-turbo",

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -179,4 +179,106 @@ describe("ZaiChatModelProvider", () => {
     );
     expect(count).toBe(Math.ceil(text.length / 2));
   });
+
+  it("should expose a Thinking Effort configurationSchema only for GLM-5.2", async () => {
+    const provider = new ZaiChatModelProvider(
+      secrets as unknown as vscode.SecretStorage,
+      "jest-agent"
+    );
+    const models = await provider.provideLanguageModelChatInformation(
+      { silent: true } as vscode.PrepareLanguageModelChatModelOptions,
+      createToken()
+    );
+
+    const glm52 = models.find((m) => m.id === "glm-5.2");
+    expect(glm52).toBeDefined();
+    const prop = glm52?.configurationSchema?.properties?.reasoningEffort;
+    expect(prop).toBeDefined();
+    expect(prop?.type).toBe("string");
+    // Only the three levels that produce a distinct outcome on GLM-5.2. The
+    // other documented values are server-side aliases that collapse onto these
+    // (xhigh→max; low/medium→high; minimal→none), so they are not offered.
+    expect(prop?.enum).toEqual(["max", "high", "none"]);
+    expect(prop?.default).toBe("max");
+    expect(prop?.group).toBe("navigation");
+
+    // Other models must not expose the picker.
+    const glm5 = models.find((m) => m.id === "glm-5");
+    expect(glm5?.configurationSchema).toBeUndefined();
+  });
+
+  it("should forward reasoning_effort for GLM-5.2 when selected in the picker", async () => {
+    const provider = new ZaiChatModelProvider(
+      secrets as unknown as vscode.SecretStorage,
+      "jest-agent"
+    );
+    const models = await provider.provideLanguageModelChatInformation(
+      { silent: true } as vscode.PrepareLanguageModelChatModelOptions,
+      createToken()
+    );
+    const glm52 = models.find((m) => m.id === "glm-5.2");
+    if (!glm52) {
+      throw new Error("glm-5.2 not found");
+    }
+
+    const messages = [vscode.LanguageModelChatMessage.User("hello")];
+    const progress = {
+      report: jest.fn(),
+    } as unknown as vscode.Progress<vscode.LanguageModelResponsePart>;
+
+    await provider.provideLanguageModelChatResponse(
+      glm52,
+      messages,
+      {
+        modelConfiguration: { reasoningEffort: "high" },
+      } as vscode.ProvideLanguageModelChatResponseOptions,
+      progress,
+      createToken()
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const requestInit = (global.fetch as jest.Mock).mock.calls[0]?.[1] as {
+      body?: string;
+    };
+    const requestBody = JSON.parse(requestInit.body ?? "{}");
+    expect(requestBody.thinking).toEqual({ type: "enabled" });
+    expect(requestBody.reasoning_effort).toBe("high");
+  });
+
+  it("should omit reasoning_effort for non-supporting models even when configured", async () => {
+    const provider = new ZaiChatModelProvider(
+      secrets as unknown as vscode.SecretStorage,
+      "jest-agent"
+    );
+    const models = await provider.provideLanguageModelChatInformation(
+      { silent: true } as vscode.PrepareLanguageModelChatModelOptions,
+      createToken()
+    );
+    const glm5 = models.find((m) => m.id === "glm-5");
+    if (!glm5) {
+      throw new Error("glm-5 not found");
+    }
+
+    const messages = [vscode.LanguageModelChatMessage.User("hello")];
+    const progress = {
+      report: jest.fn(),
+    } as unknown as vscode.Progress<vscode.LanguageModelResponsePart>;
+
+    await provider.provideLanguageModelChatResponse(
+      glm5,
+      messages,
+      {
+        modelConfiguration: { reasoningEffort: "high" },
+      } as vscode.ProvideLanguageModelChatResponseOptions,
+      progress,
+      createToken()
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const requestInit = (global.fetch as jest.Mock).mock.calls[0]?.[1] as {
+      body?: string;
+    };
+    const requestBody = JSON.parse(requestInit.body ?? "{}");
+    expect(requestBody.reasoning_effort).toBeUndefined();
+  });
 });

--- a/vscode.d.ts
+++ b/vscode.d.ts
@@ -130,7 +130,7 @@ declare module 'vscode' {
 		 * 'iso88597', 'windows1255', 'iso88598', 'iso885910', 'iso885916', 'windows1254',
 		 * 'iso88599', 'windows1258', 'gbk', 'gb18030', 'cp950', 'big5hkscs', 'shiftjis',
 		 * 'eucjp', 'euckr', 'windows874', 'iso885911', 'koi8ru', 'koi8t', 'gb2312',
-		 * 'cp865', 'cp850'.
+		 * 'cp865', 'cp850', 'cp857'.
 		 */
 		readonly encoding: string;
 
@@ -4895,13 +4895,13 @@ declare module 'vscode' {
 		 */
 		Color = 15,
 		/**
-		 * The `Reference` completion item kind.
-		 */
-		Reference = 17,
-		/**
 		 * The `File` completion item kind.
 		 */
 		File = 16,
+		/**
+		 * The `Reference` completion item kind.
+		 */
+		Reference = 17,
 		/**
 		 * The `Folder` completion item kind.
 		 */
@@ -10792,6 +10792,16 @@ declare module 'vscode' {
 		export const isNewAppInstall: boolean;
 
 		/**
+		 * Indicates whether the application is running in portable mode.
+		 *
+		 * Portable mode is enabled when the application is run from a folder that contains
+		 * a `data` directory, allowing for self-contained installations.
+		 *
+		 * Learn more about [Portable Mode](https://code.visualstudio.com/docs/editor/portable).
+		 */
+		export const isAppPortable: boolean;
+
+		/**
 		 * Indicates whether the users has telemetry enabled.
 		 * Can be observed to determine if the extension should send telemetry.
 		 */
@@ -12238,6 +12248,8 @@ declare module 'vscode' {
 
 		/**
 		 * Get the children of `element` or root if no element is passed.
+		 *
+		 * *Note:* The result is not mutated by the API consumer; readonly arrays may be cast to `T[]`.
 		 *
 		 * @param element The element from which the provider gets children. Can be `undefined`.
 		 * @returns Children of `element` or root if no element is passed.
@@ -20614,11 +20626,6 @@ declare module 'vscode' {
 		 * Various features that the model supports such as tool calling or image input.
 		 */
 		readonly capabilities: LanguageModelChatCapabilities;
-
-		/**
-		 * Whether or not the model will show up in the model picker.
-		 */
-		readonly isUserSelectable?: boolean;
 	}
 
 	/**

--- a/vscode.proposed.chatProvider.d.ts
+++ b/vscode.proposed.chatProvider.d.ts
@@ -1,0 +1,67 @@
+// Copied/adapted from VS Code repository (src/vscode-dts/vscode.proposed.chatProvider.d.ts).
+// Declares the proposed `chatProvider` API surface used by this extension:
+//   - `LanguageModelConfigurationSchema`
+//   - `LanguageModelChatInformation.configurationSchema`
+//   - `ProvideLanguageModelChatResponseOptions.modelConfiguration`
+//
+// Only additive declarations are included here (interface merging), so this file
+// does not conflict with the stable `vscode.d.ts`. The stable
+// `ProvideLanguageModelChatResponseOptions.modelOptions` remains available.
+//
+// To update: npx @vscode/dts dev
+// Can be removed once the API graduates to stable.
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	/**
+	 * A [JSON Schema](https://json-schema.org) describing configuration options
+	 * for a language model. Each property in `properties` defines a configurable
+	 * option using standard JSON Schema fields plus additional display hints.
+	 *
+	 * Declared via {@link LanguageModelChatInformation.configurationSchema}; the
+	 * configured values are merged into the request options when sending chat
+	 * requests to this model.
+	 */
+	export type LanguageModelConfigurationSchema = {
+		readonly properties?: {
+			readonly [key: string]: Record<string, any> & {
+				/**
+				 * Human-readable labels for enum values, shown instead of the raw values.
+				 * Must have the same length and order as `enum`.
+				 */
+				readonly enumItemLabels?: string[];
+				/**
+				 * The group this property belongs to. When set to `'navigation'`, the
+				 * property is shown as a primary action in the model picker.
+				 */
+				readonly group?: string;
+			};
+		};
+	};
+
+	export interface LanguageModelChatInformation {
+		/**
+		 * An optional JSON schema describing the configuration options for this model.
+		 * When set, users can specify per-model configuration (e.g. a "Thinking Effort"
+		 * picker shown next to the model picker). The configured values are forwarded
+		 * to the provider via
+		 * {@link ProvideLanguageModelChatResponseOptions.modelConfiguration}.
+		 */
+		readonly configurationSchema?: LanguageModelConfigurationSchema;
+	}
+
+	export interface ProvideLanguageModelChatResponseOptions {
+		/**
+		 * Per-model configuration provided by the user. Contains resolved values based
+		 * on the model's {@link LanguageModelChatInformation.configurationSchema},
+		 * with user overrides applied on top of schema defaults. This is the proposed
+		 * counterpart to the stable `modelOptions`.
+		 */
+		readonly modelConfiguration?: { readonly [key: string]: any };
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * GLM-5.2 モデルに「Thinking Effort」設定機能を追加。ユーザーは推論努力レベル（最大～最小）を選択でき、チャット応答の品質をコントロールできるようになりました。

* **Tests**
  * Thinking Effort機能の動作検証テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->